### PR TITLE
update comparison in readme

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["@babel/env", { "modules": false }],
+    ["@babel/env", { "modules": false, "loose": true }],
     "@babel/preset-react"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -20,31 +20,34 @@ This comparison doesn't pretend to be objective and was done for personal purpos
 
 Here are the results for production JavaScript bundle size.
 
-| Bundler | Minified | Gzipped |
-|---------|----------|---------|
-| Webpack | 648 kB   | 185 kB  |
-| Parcel  | 623 kB   | 164 kB  |
-| Rollup  | 432 kB   | 129 kB  |
+| Bundler     | Minified | Gzipped |
+|-------------|----------|---------|
+| Webpack     | 636 kB   | 184 kB  |
+| Webpack-adv | 624 kB   | 184 kB  |
+| Parcel      | 623 kB   | 165 kB  |
+| Rollup      | 429 kB   | 129 kB  |
 
 ## Development Build
 
 Here are the results for development build times. For Parcel there are two values for start since it has built-in cache. All the values is an average over 10 runs.
 
-| Bundler |       Start       | Reload  |
-|---------|-------------------|---------|
-| Webpack | 5040 ms           | 861 ms  |
-| Parcel  | 9864 ms (2445 ms) | 753 ms  |
-| Rollup  | 11463 ms          | 5126 ms |
+| Bundler     |       Start       | Reload  |
+|-------------|-------------------|---------|
+| Webpack     | 5040 ms           | 861 ms  |
+| Webpack-adv | 3781 ms           | 264 ms  |
+| Parcel      | 9864 ms (2445 ms) | 753 ms  |
+| Rollup      | 11463 ms          | 5126 ms |
 
 ## Production Build
 
 Here are the results for production build times. For Parcel and Webpack there are two values since both have cache. Webpack has cache for [Terser Plugin](https://github.com/webpack-contrib/terser-webpack-plugin). All the values is an average over 10 runs.
 
-| Bundler |        Time        |
-|---------|--------------------|
-| Webpack | 15421 ms (4686 ms) |
-| Parcel  | 11192 ms (1271 ms) |
-| Rollup  | 16440 ms           |
+| Bundler     |        Time        |
+|-------------|--------------------|
+| Webpack     | 15421 ms (4686 ms) |
+| Webpack-adv | 15114 ms (3824 ms) |
+| Parcel      | 11192 ms (1271 ms) |
+| Rollup      | 16440 ms           |
 
 ## Usage Notes
 
@@ -78,6 +81,13 @@ babel-loader
 style-loader
 css-loader
 sass-loader
+```
+
+Advanced configuration also requires
+
+```
+cache-loader
+thread-loader
 ```
 
 ### Parcel
@@ -122,6 +132,6 @@ rollup-plugin-visualizer
 
 ## Conclusion
 
-- Use Webpack 4 by default. It's flexible and user-friendly enough for app development. There is a learning curve, but once you get it, it's not very complicated to use. The documentation became a lot better last time and the community is very big.
+- Use Webpack 4 by default. It's flexible and user-friendly enough for app development. There is a learning curve, but once you get it, it's not very complicated to use. The documentation became a lot better last time and the community is very big. After getting familiar with core concepts you can get a much smoother and snappier work flow than with other bundlers.
 - Use Parcel for simple scenarios. It's easy to setup and very fast. It's also a good option for beginners. Don't use it if you wish to do customizations and tweaks for your builds, in the long term it may cause problems. The documentation may lack some of the important details and it's a pain to fix little quirks. It's also still immature, so expect to face with bugs.
 - Use Rollup for library development and if bundle size is something very critical for you. The developer's experience is not the best here and you need to understand the tradeoffs for a small bundle size and minimalistic philosophy behind it. It's a solid tool though. The documentation would be better if it could provide more real-life examples of usage for common scenarios.

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Here are the results for production JavaScript bundle size.
 
 | Bundler | Minified | Gzipped |
 |---------|----------|---------|
-| Webpack | 709 kB   | 192 kB  |
-| Parcel  | 687 kB   | 180 kB  |
-| Rollup  | 464 kB   | 139 kB  |
+| Webpack | 648 kB   | 185 kB  |
+| Parcel  | 623 kB   | 164 kB  |
+| Rollup  | 432 kB   | 129 kB  |
 
 ## Development Build
 
@@ -32,9 +32,9 @@ Here are the results for development build times. For Parcel there are two value
 
 | Bundler |       Start       | Reload  |
 |---------|-------------------|---------|
-| Webpack | 5226 ms           | 967 ms  |
-| Parcel  | 8488 ms (2445 ms) | 692 ms  |
-| Rollup  | 12230 ms          | 3840 ms |
+| Webpack | 5040 ms           | 861 ms  |
+| Parcel  | 9864 ms (2445 ms) | 753 ms  |
+| Rollup  | 11463 ms          | 5126 ms |
 
 ## Production Build
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "scripts": {
     "webpack:serve": "webpack-dev-server --colors --config ./webpack/development.js",
     "webpack:build": "NODE_ENV=production webpack -p --colors --config ./webpack/production.js",
+    "webpack-advanced:serve": "webpack-dev-server --colors --config ./webpack-advanced/development.js",
+    "webpack-advanced:build": "NODE_ENV=production webpack -p --colors --config ./webpack-advanced/production.js",
     "parcel:serve": "parcel serve app/src/index.html --open --out-dir ./dist/parcel",
     "parcel:build": "NODE_ENV=production parcel build app/src/index.html --out-dir ./dist/parcel --public-url ./",
     "rollup:serve": "rollup --watch --config ./rollup/development.js",
@@ -21,6 +23,7 @@
     "@babel/preset-react": "7.0.0",
     "@babel/register": "7.0.0",
     "babel-loader": "8.0.4",
+    "cache-loader": "^2.0.1",
     "css-loader": "2.0.1",
     "exports-loader": "0.7.0",
     "imports-loader": "0.8.0",
@@ -42,6 +45,7 @@
     "rollup-plugin-visualizer": "0.9.2",
     "sass-loader": "7.1.0",
     "style-loader": "0.23.1",
+    "thread-loader": "^2.1.2",
     "webpack": "4.27.1",
     "webpack-cli": "3.1.2",
     "webpack-dev-server": "3.1.10"

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "author": "TehCookies <contact@tehcookies.com>",
   "license": "MIT",
   "scripts": {
-    "webpack:serve": "webpack-dev-server --progress --colors --config ./webpack/development.js",
-    "webpack:build": "NODE_ENV=production webpack -p --progress --colors --config ./webpack/production.js",
+    "webpack:serve": "webpack-dev-server --colors --config ./webpack/development.js",
+    "webpack:build": "NODE_ENV=production webpack -p --colors --config ./webpack/production.js",
     "parcel:serve": "parcel serve app/src/index.html --open --out-dir ./dist/parcel",
     "parcel:build": "NODE_ENV=production parcel build app/src/index.html --out-dir ./dist/parcel --public-url ./",
     "rollup:serve": "rollup --watch --config ./rollup/development.js",

--- a/webpack-advanced/development.js
+++ b/webpack-advanced/development.js
@@ -74,6 +74,5 @@ module.exports = {
     historyApiFallback: true,
     open: true
   },
-  // devtool: 'source-map'
   devtool: process.env.npm_config_sourcemaps ? 'inline-source-map' : 'inline-eval',
 };

--- a/webpack-advanced/development.js
+++ b/webpack-advanced/development.js
@@ -1,0 +1,79 @@
+const webpack = require('webpack');
+const path = require('path');
+const root = path.resolve(__dirname, '..');
+
+const cacheDir = path.resolve(__dirname, '..', 'node_modules', '.cache');
+
+const getThreadLoader = name => ({
+    loader: 'thread-loader',
+    options: {
+        workerParallelJobs: 50,
+        poolRespawn: false,
+        name
+    }
+});
+
+module.exports = {
+  mode: 'development',
+  context: root,
+  entry: path.resolve(root, 'app', 'src', 'index.js'),
+  output: {
+    path: path.resolve(root, 'dist', 'webpack'),
+    publicPath: '/',
+    filename: 'bundle.js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+          use: [
+              {
+                  loader: 'cache-loader',
+                  options: {
+                      cacheDirectory: path.resolve(cacheDir, 'js')
+                  }
+              },
+              getThreadLoader('js'),
+              {
+                  loader: 'babel-loader',
+                  options: {
+                      cacheDirectory: path.resolve(cacheDir, 'babel')
+                  }
+              }
+          ]
+      },
+      {
+        test: /\.scss$/,
+          use: [
+              {
+                  loader: 'cache-loader',
+                  options: {
+                      cacheDirectory: path.resolve(cacheDir, 'css')
+                  }
+              },
+              getThreadLoader('css'),
+              'style-loader',
+              'css-loader',
+              'sass-loader'
+          ]
+      }
+    ]
+  },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.ProvidePlugin({
+      fetch: 'imports-loader?this=>global!exports-loader?global.fetch!whatwg-fetch'
+    })
+  ],
+  devServer: {
+    contentBase: path.resolve(root, 'dist', 'webpack'),
+    publicPath: '/',
+    compress: true,
+    hot: true,
+    historyApiFallback: true,
+    open: true
+  },
+  // devtool: 'source-map'
+  devtool: process.env.npm_config_sourcemaps ? 'inline-source-map' : 'inline-eval',
+};

--- a/webpack-advanced/production.js
+++ b/webpack-advanced/production.js
@@ -1,0 +1,32 @@
+const webpack = require('webpack');
+const path = require('path');
+const root = path.resolve(__dirname, '..');
+
+module.exports = {
+  mode: 'production',
+  context: root,
+  entry: path.resolve(root, 'app', 'src', 'index.js'),
+  output: {
+    path: path.resolve(root, 'dist', 'webpack'),
+    publicPath: '/',
+    filename: 'bundle.js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+        use: ['thread-loader', 'babel-loader']
+      },
+      {
+        test: /\.scss$/,
+        use: ['thread-loader', 'style-loader', 'css-loader', 'sass-loader']
+      }
+    ]
+  },
+  plugins: [
+    new webpack.ProvidePlugin({
+      fetch: 'imports-loader?this=>global!exports-loader?global.fetch!whatwg-fetch'
+    })
+  ]
+};


### PR DESCRIPTION
Hi, I've come across your example and I believe there are a few things we can improve around webpack specifically and overall. 

- we can add `loose: true` to a `@babel/preset-env` option, which slightly reduces the build size
- if we have a speedy build for webpack we do not need the `--progress` flag, it also increases the build time 0.5/0.7s
- we can add a `package-lock.json` file or specify the bundlers versions directly. Below are my results for webpack 4.27.1, Parcel 1.10.3 and Rollup 0.63.4

As a side note which is not included in this PR is the incremental build for `webpack:serve` can be reduced down to ~400ms if set up right `cache-loader`. I was not sure wether this repo is more of a comparison for a zero-config setups or how well we can configure each in order to see the performance difference. I will be happy to improve webpack build times as an addition to this PR or do it in anothher PR.

Either way thank you for the repo!